### PR TITLE
Add option to pass if claim doesnt exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ plugins:
     - path: requestor.groups
       contains: developer-grp
       output_header: X-JWT-Requestor-Groups
-      allow_if_undefined: true
+      allow_undefined: false
     - path: unexisted_claim
       output_header: X-JWT-Unexisted-Claim
-      allow_if_undefined: true
+      allow_undefined: true
 
 ```
 
@@ -122,7 +122,7 @@ Any node/element of the JWT can be output in the HTTP headers to be sent to your
 
 ```
 
-### allow_if_undefined (optional)
+### allow_undefined (optional)
 
 Values can be either true or false (false is the default). When this option is enabled it will set the value of HTTP header for this claim to an empty string if the claim doesn't exist or is holding a value of undefined or null. If not, then the claim is required and should be part of the payload
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Consider the following JWT data from a decoded token...
 ``` jsonc
 {
   // Payload data format can be totally arbitrary to your needs.  This example is meant to demonstrate the capabilities of the jwt-claims-advanced plugin
+  "jti": "some-unique-id",
   "requestor": {
     "id": "you-are-number-6",
     "groups": [
@@ -83,6 +84,10 @@ plugins:
     - path: requestor.groups
       contains: developer-grp
       output_header: X-JWT-Requestor-Groups
+      allow_if_undefined: true
+    - path: unexisted_claim
+      output_header: X-JWT-Unexisted-Claim
+      allow_if_undefined: true
 
 ```
 
@@ -113,8 +118,13 @@ Any node/element of the JWT can be output in the HTTP headers to be sent to your
   X-JWT-Requestor: { "id": "you-are-number-6", "groups": [ "admin-grp", "sales-grp", "developer-grp", "customer-grp" ], "meta": { "what": "eva" } }
   X-JWT-Requestor-Groups: [ "admin-grp", "sales-grp", "developer-grp", "customer-grp" ]
   X-JWT-Expires-At: 100353266160
+  X-JWT-Unexisted-Claim: ""
 
 ```
+
+### allow_if_undefined (optional)
+
+Values can be either true or false (false is the default). When this option is enabled it will set the value of HTTP header for this claim to an empty string if the claim doesn't exist or is holding a value of undefined or null. If not, then the claim is required and should be part of the payload
 
 ### equals
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ plugins:
       contains: developer-grp
       output_header: X-JWT-Requestor-Groups
       allow_undefined: false
-    - path: unexisted_claim
-      output_header: X-JWT-Unexisted-Claim
+    - path: nonexistant_claim
+      output_header: X-JWT-Nonexistant-Claim
       allow_undefined: true
 
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Any node/element of the JWT can be output in the HTTP headers to be sent to your
   X-JWT-Requestor: { "id": "you-are-number-6", "groups": [ "admin-grp", "sales-grp", "developer-grp", "customer-grp" ], "meta": { "what": "eva" } }
   X-JWT-Requestor-Groups: [ "admin-grp", "sales-grp", "developer-grp", "customer-grp" ]
   X-JWT-Expires-At: 100353266160
-  X-JWT-Unexisted-Claim: ""
+  X-JWT-Nonexistant-Claim: ""
 
 ```
 

--- a/handler.lua
+++ b/handler.lua
@@ -253,8 +253,9 @@ function plugin:access(config)
 
     -- Output in headers...
     if claim_config.output_header ~= nil then
-      if payload_claim_item == nil then
-        kong.service.request.set_header(claim_config.output_header, "none")
+      if payload_claim_item == nil and claim_config.allow_if_undefined then
+        kong.service.request.set_header(claim_config.output_header, "")
+        return
       end
       local payload_claim_item_as_text = payload_claim_item
       if type(payload_claim_item) == "table" then

--- a/handler.lua
+++ b/handler.lua
@@ -253,7 +253,7 @@ function plugin:access(config)
 
     -- Output in headers...
     if claim_config.output_header ~= nil then
-      if payload_claim_item == nil and claim_config.allow_if_undefined then
+      if payload_claim_item == nil and claim_config.allow_undefined then
         kong.service.request.set_header(claim_config.output_header, "")
         return
       end

--- a/handler.lua
+++ b/handler.lua
@@ -253,6 +253,9 @@ function plugin:access(config)
 
     -- Output in headers...
     if claim_config.output_header ~= nil then
+      if payload_claim_item == nil then
+        kong.service.request.set_header(claim_config.output_header, "none")
+      end
       local payload_claim_item_as_text = payload_claim_item
       if type(payload_claim_item) == "table" then
         payload_claim_item_as_text = json.encode(payload_claim_item)

--- a/kong-plugin-jwt-claims-advanced-0.3-0.rockspec
+++ b/kong-plugin-jwt-claims-advanced-0.3-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-jwt-claims-advanced"
-version = "0.2-0"
+version = "0.3-0"
 description = {
 	summary = "A Kong plugin to allow custom JWT claims/values checking, validation, and forwarding as custo HTTP headers.",
 	license = "Apache 2.0",
@@ -9,7 +9,7 @@ dependencies = {
 }
 source = {
 	url = "git+https://github.com/tucows/kong-plugin-jwt-claims-advanced.git",
-	tag = "v0.2-0",
+	tag = "v0.3-0",
 }
 build = {
 	type = "builtin",

--- a/schema.lua
+++ b/schema.lua
@@ -61,6 +61,14 @@ return {
                       type = "string",
                     },
                   },
+
+                  {
+                    -- Example: true / false
+                    allow_if_undefined = {
+                      type = "boolean",
+                      default = false
+                    },
+                  },
                   -- This claim (array/table) must contain the value specified with the "contains" param
                   {
                     contains = {
@@ -133,7 +141,7 @@ return {
                 },
                 entity_checks = {
                   {
-                    at_least_one_of = { "output_header", "contains", "does_not_contain", "contains_one_of", "contains_none_of", "equals", "does_not_equal", "equals_one_of", "equals_none_of" },
+                    at_least_one_of = { "output_header", "allow_if_undefined", "contains", "does_not_contain", "contains_one_of", "contains_none_of", "equals", "does_not_equal", "equals_one_of", "equals_none_of" },
                   },
                 },
               },

--- a/schema.lua
+++ b/schema.lua
@@ -64,7 +64,7 @@ return {
 
                   {
                     -- Example: true / false
-                    allow_if_undefined = {
+                    allow_undefined = {
                       type = "boolean",
                       default = false
                     },
@@ -141,7 +141,7 @@ return {
                 },
                 entity_checks = {
                   {
-                    at_least_one_of = { "output_header", "allow_if_undefined", "contains", "does_not_contain", "contains_one_of", "contains_none_of", "equals", "does_not_equal", "equals_one_of", "equals_none_of" },
+                    at_least_one_of = { "output_header", "allow_undefined", "contains", "does_not_contain", "contains_one_of", "contains_none_of", "equals", "does_not_equal", "equals_one_of", "equals_none_of" },
                   },
                 },
               },


### PR DESCRIPTION
This PR updates the plugin configuration adding new option to pass if claim doesn't exist

If `output_header` is set and the claim doesn't exist in the payload, the default behavior is to return response of 500.

BUT, if `allow_if_undefined` is set to true, it's gonna set empty string in the output header.

## Testing
This version of the plugin is used in barndoor, specially in [this PR](https://github.com/tucowsinc/barndoor/pull/1323)